### PR TITLE
Add newlines before and after `log`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ function tscCheck(filename: string = 'tsc_raw.log') {
     const log = readFileSync(filename, 'utf8');
     if (log.length) {
       fail('TypeScript hasn\'t passed, see below for full logs');
-      markdown(`### TypeScript Fails\n\n\`\`\`${log}\`\`\``);
+      markdown(`### TypeScript Fails\n\n\`\`\`\n${log}\n\`\`\``);
     }
   }
 }


### PR DESCRIPTION
Hi, first thank you for providing this plugin!

I noticed danger's comment can be corrupt depending on the tsc output because there are no newlines around `log`.
For instance, one of the comments we got while running is:

<img width="1653" alt="Screen Shot 2021-08-19 at 6 50 15 PM" src="https://user-images.githubusercontent.com/1391330/130166445-d58fa2df-58ff-4bf9-9e36-323da2d94958.png">

This is because generated string was something like this:

<img width="211" alt="Screen Shot 2021-08-19 at 6 52 39 PM" src="https://user-images.githubusercontent.com/1391330/130166561-8d1dc91a-5844-41f2-a3ef-a7ee82391dc6.png">

which looks like:

```tsc log string
```

Similar thing could happen if output doesn't contain a newline at the end of the file.
To avoid them, what do you think of adding newlines before/after `log` ?

Thanks in advance!